### PR TITLE
Bump i18n and backport CVE-2013-4491

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', version)
   s.add_dependency('activemodel',   version)
   s.add_dependency('builder',       '~> 2.1.2')
-  s.add_dependency('i18n',          '~> 0.5.0')
+  s.add_dependency('i18n',          '~> 0.6')
   s.add_dependency('rack',          '~> 1.2.5')
   s.add_dependency('rack-test',     '~> 0.5.7')
   s.add_dependency('rack-mount',    '~> 0.6.14')

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -1,24 +1,14 @@
 require 'action_view/helpers/tag_helper'
 require 'i18n/exceptions'
 
-module I18n
-  class ExceptionHandler
-    include Module.new {
-      def call(exception, locale, key, options)
-        exception.is_a?(MissingTranslationData) && options[:rescue_format] == :html ? super.html_safe : super
-      end
-    }
-  end
-end
-
 module ActionView
   # = Action View Translation Helpers
   module Helpers
     module TranslationHelper
       # Delegates to I18n#translate but also performs three additional functions.
       #
-      # First, it'll pass the :rescue_format => :html option to I18n so that any caught
-      # MissingTranslationData exceptions will be turned into inline spans that
+      # First, it will ensure that any thrown +MissingTranslation+ messages will be turned 
+      # into inline spans that:
       #
       #   * have a "translation-missing" class set,
       #   * contain the missing key as a title attribute and
@@ -44,7 +34,9 @@ module ActionView
       # naming convention helps to identify translations that include HTML tags so that
       # you know what kind of output to expect when you call translate in a template.
       def translate(key, options = {})
-        options.merge!(:rescue_format => :html) unless options.key?(:rescue_format)
+        # If the user has specified rescue_format then pass it all through, otherwise use
+        # raise and do the work ourselves
+        options[:raise] = true unless options.key?(:raise) || options.key?(:rescue_format)
         if html_safe_translation_key?(key)
           html_safe_options = options.dup
           options.except(*I18n::RESERVED_KEYS).each do |name, value|
@@ -58,6 +50,9 @@ module ActionView
         else
           I18n.translate(scope_key_by_partial(key), options)
         end
+      rescue I18n::MissingTranslationData => e
+        keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
+        content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => "translation missing: #{keys.join('.')}")
       end
       alias :t :translate
 

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -30,7 +30,7 @@ class TranslationHelperTest < ActiveSupport::TestCase
   end
 
   def test_delegates_to_i18n_setting_the_rescue_format_option_to_html
-    I18n.expects(:translate).with(:foo, :locale => 'en', :rescue_format => :html).returns("")
+    I18n.expects(:translate).with(:foo, :locale => 'en', :raise=>true).returns("")
     translate :foo, :locale => 'en'
   end
 

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activesupport', version)
   s.add_dependency('builder',       '~> 2.1.2')
-  s.add_dependency('i18n',          '~> 0.5.0')
+  s.add_dependency('i18n',          '~> 0.6')
 end


### PR DESCRIPTION
- Bump i18n to 0.6.x to fix errors from travis
- Back port [CVE patch from 3-1](https://github.com/rails/rails/commit/31cfb3c71371f1aab106d83f689a9682bcee3eab) which fixes errors caused by upgrading to 0.6 + makes us safe.

Profit :moneybag: 

/cc @tamird 
