### PR TITLE
Update rack dependency to 1.4.x

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activemodel',   version)
   s.add_dependency('builder',       '~> 2.1.2')
   s.add_dependency('i18n',          '~> 0.6')
-  s.add_dependency('rack',          '~> 1.2.5')
+  s.add_dependency('rack',          '~> 1.4.0')
   s.add_dependency('rack-test',     '~> 0.5.7')
   s.add_dependency('rack-mount',    '~> 0.6.14')
   s.add_dependency('tzinfo',        '~> 0.3.23')


### PR DESCRIPTION
1.4.x is the best what we can get now, 1.5.x breaks ActionPack tests.

/cc @tamird 
