### PR TITLE
Change rack version for 2.3

### DIFF
--- a/actionpack/Rakefile
+++ b/actionpack/Rakefile
@@ -82,7 +82,7 @@ spec = Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('activesupport', '= 2.3.18' + PKG_BUILD)
-  s.add_dependency('rack', '~> 1.4')
+  s.add_dependency('rack', '~> 1.4.0')
 
   s.require_path = 'lib'
   s.autorequire = 'action_controller'

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'activesupport', '= 2.3.18'
-  s.add_dependency 'rack', '~> 1.4'
+  s.add_dependency 'rack', '~> 1.4.0'
 end

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -31,7 +31,7 @@ rescue LoadError
   end
 end
 
-gem 'rack', '~> 1.4'
+gem 'rack', '~> 1.4.0'
 require 'rack'
 require 'action_controller/cgi_ext'
 


### PR DESCRIPTION
`~> 1.4` will allow `1.5.x` which introduces breaking changes.

We'd like to use 1.4.x but < 1.5

/ref: #7 #2 
/cc: @tamird 
