### PR TITLE
Backport i18n stuff

### DIFF
--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -176,6 +176,10 @@ module ActionView #:nodoc:
     cattr_accessor :field_error_proc
     @@field_error_proc = Proc.new{ |html_tag, instance| "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe }
 
+    # Specify whether an error should be raised for missing translations
+    cattr_accessor :raise_on_missing_translations
+    @@raise_on_missing_translations = false
+
     class_attribute :helpers
     class_attribute :_routes
 

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -36,7 +36,13 @@ module ActionView
       def translate(key, options = {})
         # If the user has specified rescue_format then pass it all through, otherwise use
         # raise and do the work ourselves
-        options[:raise] = true unless options.key?(:raise) || options.key?(:rescue_format)
+        if options.key?(:raise) || options.key?(:rescue_format)
+          raise_error = options[:raise] || options[:rescue_format]
+        else
+          raise_error = false
+          options[:raise] = true
+        end
+
         if html_safe_translation_key?(key)
           html_safe_options = options.dup
           options.except(*I18n::RESERVED_KEYS).each do |name, value|
@@ -51,6 +57,8 @@ module ActionView
           I18n.translate(scope_key_by_partial(key), options)
         end
       rescue I18n::MissingTranslationData => e
+        raise e if raise_error
+
         keys = I18n.normalize_keys(e.locale, e.key, e.options[:scope])
         content_tag('span', keys.last.to_s.titleize, :class => 'translation_missing', :title => "translation missing: #{keys.join('.')}")
       end

--- a/actionpack/lib/action_view/helpers/translation_helper.rb
+++ b/actionpack/lib/action_view/helpers/translation_helper.rb
@@ -36,10 +36,10 @@ module ActionView
       def translate(key, options = {})
         # If the user has specified rescue_format then pass it all through, otherwise use
         # raise and do the work ourselves
-        if options.key?(:raise) || options.key?(:rescue_format)
-          raise_error = options[:raise] || options[:rescue_format]
-        else
-          raise_error = false
+        options[:raise] ||= ActionView::Base.raise_on_missing_translations
+
+        raise_error = options[:raise] || options.key?(:rescue_format)
+        unless raise_error
           options[:raise] = true
         end
 

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -52,6 +52,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
+  def test_raises_missing_translation_message_with_raise_option
+    assert_raise(I18n::MissingTranslationData) do
+      translate(:"translations.missing", :raise => true)
+    end
+  end
+
   def test_i18n_translate_defaults_to_nil_rescue_format
     expected = 'translation missing: en.translations.missing'
     assert_equal expected, I18n.translate(:"translations.missing")

--- a/actionpack/test/template/translation_helper_test.rb
+++ b/actionpack/test/template/translation_helper_test.rb
@@ -52,6 +52,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal false, translate(:"translations.missing", :rescue_format => nil).html_safe?
   end
 
+  def test_raises_missing_translation_message_with_raise_config_option
+    ActionView::Base.raise_on_missing_translations = true
+
+    assert_raise(I18n::MissingTranslationData) do
+      translate("translations.missing")
+    end
+  ensure
+    ActionView::Base.raise_on_missing_translations = false
+  end
+
   def test_raises_missing_translation_message_with_raise_option
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", :raise => true)


### PR DESCRIPTION
Fixes regressions after 50e0b44dbff79aac354d10021541c8169b4d0a5c and adds `config.action_view.raise_on_missing_translations` setting.

Backported from `4-0-stable`.

/cc @tamird 
