### PR TITLE
Remove the use of String#% when formatting durations in log messages

### DIFF
--- a/actionmailer/lib/action_mailer/log_subscriber.rb
+++ b/actionmailer/lib/action_mailer/log_subscriber.rb
@@ -4,12 +4,12 @@ module ActionMailer
   class LogSubscriber < ActiveSupport::LogSubscriber
     def deliver(event)
       recipients = Array.wrap(event.payload[:to]).join(', ')
-      info("\nSent mail to #{recipients} (%1.fms)" % event.duration)
+      info("\nSent mail to #{recipients} (#{format_duration(event.duration)})")
       debug(event.payload[:mail])
     end
 
     def receive(event)
-      info("\nReceived mail (%.1fms)" % event.duration)
+      info("\nReceived mail (#{format_duration(event.duration)})")
       debug(event.payload[:mail])
     end
 

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -20,16 +20,14 @@ module ActionController
       if status.nil? && payload[:exception].present?
         status = Rack::Utils.status_code(ActionDispatch::ShowExceptions.rescue_responses[payload[:exception].first]) rescue nil 
       end 
-      message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in %.0fms" % event.duration
+      message = "Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{format_duration(event.duration)}"
       message << " (#{additions.join(" | ")})" unless additions.blank?
 
       info(message)
     end
 
     def send_file(event)
-      message = "Sent file %s"
-      message << " (%.1fms)"
-      info(message % [event.payload[:path], event.duration])
+      info("Sent file #{event.payload[:path]} (#{format_duration(event.duration)})")
     end
 
     def redirect_to(event)
@@ -37,7 +35,7 @@ module ActionController
     end
 
     def send_data(event)
-      info("Sent data %s (%.1fms)" % [event.payload[:filename], event.duration])
+      info("Sent data #{event.payload[:filename]}  (#{format_duration(event.duration)})")
     end
 
     %w(write_fragment read_fragment exist_fragment?
@@ -46,7 +44,8 @@ module ActionController
         def #{method}(event)
           key_or_path = event.payload[:key] || event.payload[:path]
           human_name  = #{method.to_s.humanize.inspect}
-          info("\#{human_name} \#{key_or_path} (%.1fms)" % event.duration)
+          duration = format_duration(event.duration)
+          info("\#{human_name} \#{key_or_path} \#{duration}")
         end
       METHOD
     end

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -118,5 +118,9 @@ module ActiveSupport
       bold  = bold ? BOLD : ""
       "#{bold}#{color}#{text}#{CLEAR}"
     end
+
+    def format_duration(duration)
+      "%.1fms" % duration
+    end
   end
 end


### PR DESCRIPTION
@strzalek patch downloaded form https://groups.google.com/forum/#!topic/ruby-security-ann/yvlR1Vx44c8

This avoids potential format string vulnerabilities where user-provided
data is interpolated into the log message before String#% is called.

Conflicts:
    actionpack/lib/action_controller/log_subscriber.rb

Conflicts:
    actionpack/lib/action_controller/log_subscriber.rb

Signed-off-by: Neal Harris neal@squareup.com
