### PR TITLE
Backport ActiveSupport::MessageEncryptor/Verifier from Rails 4.0.4

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -1,70 +1,107 @@
 require 'openssl'
+require 'base64'
+require 'active_support/core_ext/array/extract_options'
+require 'securerandom'
 
 module ActiveSupport
-  # MessageEncryptor is a simple way to encrypt values which get stored somewhere 
-  # you don't trust.
-  # 
-  # The cipher text and initialization vector are base64 encoded and returned to you.
+  # MessageEncryptor is a simple way to encrypt values which get stored
+  # somewhere you don't trust.
   #
-  # This can be used in situations similar to the MessageVerifier, but where you don't
-  # want users to be able to determine the value of the payload.
+  # The cipher text and initialization vector are base64 encoded and returned
+  # to you.
+  #
+  # This can be used in situations similar to the <tt>MessageVerifier</tt>, but
+  # where you don't want users to be able to determine the value of the payload.
+  #
+  #   salt  = SecureRandom.random_bytes(64) 
+  #   key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt) # => "\x89\xE0\x156\xAC..."
+  #   crypt = ActiveSupport::MessageEncryptor.new(key)                       # => #<ActiveSupport::MessageEncryptor ...>
+  #   encrypted_data = crypt.encrypt_and_sign('my secret data')              # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
+  #   crypt.decrypt_and_verify(encrypted_data)                               # => "my secret data"
   class MessageEncryptor
-    class InvalidMessage < StandardError; end
-    OpenSSLCipherError = OpenSSL::Cipher.const_defined?(:CipherError) ? OpenSSL::Cipher::CipherError : OpenSSL::CipherError
+    module NullSerializer #:nodoc:
+      def self.load(value)
+        value
+      end
 
-    def initialize(secret, cipher = 'aes-256-cbc')
-      @secret = secret
-      @cipher = cipher
+      def self.dump(value)
+        value
+      end
     end
-    
-    def encrypt(value)
+
+    class InvalidMessage < StandardError; end
+    OpenSSLCipherError = OpenSSL::Cipher::CipherError
+
+    # Initialize a new MessageEncryptor. +secret+ must be at least as long as
+    # the cipher key size. For the default 'aes-256-cbc' cipher, this is 256
+    # bits. If you are using a user-entered secret, you can generate a suitable
+    # key with <tt>OpenSSL::Digest::SHA256.new(user_secret).digest</tt> or
+    # similar.
+    #
+    # Options:
+    # * <tt>:cipher</tt>     - Cipher to use. Can be any cipher returned by
+    #   <tt>OpenSSL::Cipher.ciphers</tt>. Default is 'aes-256-cbc'.
+    # * <tt>:serializer</tt> - Object serializer to use. Default is +Marshal+.
+    def initialize(secret, *signature_key_or_options)
+      options = signature_key_or_options.extract_options!
+      sign_secret = signature_key_or_options.first
+      @secret = secret
+      @sign_secret = sign_secret
+      @cipher = options[:cipher] || 'aes-256-cbc'
+      @verifier = MessageVerifier.new(@sign_secret || @secret, :serializer => NullSerializer)
+      @serializer = options[:serializer] || Marshal
+    end
+
+    # Encrypt and sign a message. We need to sign the message in order to avoid
+    # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    def encrypt_and_sign(value)
+      verifier.generate(_encrypt(value))
+    end
+
+    # Decrypt and verify a message. We need to verify the message in order to
+    # avoid padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    def decrypt_and_verify(value)
+      _decrypt(verifier.verify(value))
+    end
+
+    private
+
+    def _encrypt(value)
       cipher = new_cipher
+      cipher.encrypt
+      cipher.key = @secret
+
       # Rely on OpenSSL for the initialization vector
       iv = cipher.random_iv
-      
-      cipher.encrypt 
-      cipher.key = @secret
-      cipher.iv  = iv
-      
-      encrypted_data = cipher.update(Marshal.dump(value)) 
+
+      encrypted_data = cipher.update(@serializer.dump(value))
       encrypted_data << cipher.final
 
-      [encrypted_data, iv].map {|v| ActiveSupport::Base64.encode64s(v)}.join("--")
+      [encrypted_data, iv].map {|v| ::Base64.strict_encode64(v)}.join("--")
     end
-    
-    def decrypt(encrypted_message)
+
+    def _decrypt(encrypted_message)
       cipher = new_cipher
-      encrypted_data, iv = encrypted_message.split("--").map {|v| ActiveSupport::Base64.decode64(v)}
-      
+      encrypted_data, iv = encrypted_message.split("--").map {|v| ::Base64.decode64(v)}
+
       cipher.decrypt
       cipher.key = @secret
       cipher.iv  = iv
 
       decrypted_data = cipher.update(encrypted_data)
       decrypted_data << cipher.final
-      
-      Marshal.load(decrypted_data)
+
+      @serializer.load(decrypted_data)
     rescue OpenSSLCipherError, TypeError
       raise InvalidMessage
     end
-    
-    def encrypt_and_sign(value)
-      verifier.generate(encrypt(value))
+
+    def new_cipher
+      OpenSSL::Cipher::Cipher.new(@cipher)
     end
-    
-    def decrypt_and_verify(value)
-      decrypt(verifier.verify(value))
+
+    def verifier
+      @verifier
     end
-    
-    
-    
-    private 
-      def new_cipher
-        OpenSSL::Cipher::Cipher.new(@cipher)
-      end
-      
-      def verifier
-        MessageVerifier.new(@secret)
-      end
   end
 end

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -1,79 +1,76 @@
+require 'base64'
+require 'active_support/core_ext/object/blank'
+
 module ActiveSupport
-  # MessageVerifier makes it easy to generate and verify messages which are signed
-  # to prevent tampering.
-  # 
-  # This is useful for cases like remember-me tokens and auto-unsubscribe links where the
-  # session store isn't suitable or available.
+  # +MessageVerifier+ makes it easy to generate and verify messages which are
+  # signed to prevent tampering.
+  #
+  # This is useful for cases like remember-me tokens and auto-unsubscribe links
+  # where the session store isn't suitable or available.
   #
   # Remember Me:
   #   cookies[:remember_me] = @verifier.generate([@user.id, 2.weeks.from_now])
-  # 
+  #
   # In the authentication filter:
   #
   #   id, time = @verifier.verify(cookies[:remember_me])
   #   if time < Time.now
   #     self.current_user = User.find(id)
   #   end
-  # 
+  #
+  # By default it uses Marshal to serialize the message. If you want to use
+  # another serialization method, you can set the serializer in the options
+  # hash upon initialization:
+  #
+  #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', serializer: YAML)
   class MessageVerifier
     class InvalidSignature < StandardError; end
-    
-    def initialize(secret, digest = 'SHA1')
+
+    def initialize(secret, options = {})
       @secret = secret
-      @digest = digest
+      if options.is_a? String
+        @digest     = options
+        @serializer = nil
+      else
+        @digest     = options[:digest]
+        @serializer = options[:serializer]
+      end
+
+      @digest     ||= 'SHA1'
+      @serializer ||= Marshal
     end
-    
+
     def verify(signed_message)
       raise InvalidSignature if signed_message.blank?
 
       data, digest = signed_message.split("--")
       if data.present? && digest.present? && secure_compare(digest, generate_digest(data))
-        Marshal.load(ActiveSupport::Base64.decode64(data))
+        @serializer.load(::Base64.decode64(data))
       else
         raise InvalidSignature
       end
     end
-    
+
     def generate(value)
-      data = ActiveSupport::Base64.encode64s(Marshal.dump(value))
+      data = ::Base64.strict_encode64(@serializer.dump(value))
       "#{data}--#{generate_digest(data)}"
     end
-    
-    private
-      if "foo".respond_to?(:force_encoding)
-        # constant-time comparison algorithm to prevent timing attacks
-        def secure_compare(a, b)
-          a = a.dup.force_encoding(Encoding::BINARY)
-          b = b.dup.force_encoding(Encoding::BINARY)
 
-          if a.length == b.length
-            result = 0
-            for i in 0..(a.length - 1)
-              result |= a[i].ord ^ b[i].ord
-            end
-            result == 0
-          else
-            false
-          end
-        end
-      else
-        # For <= 1.8.6
-        def secure_compare(a, b)
-          if a.length == b.length
-            result = 0
-            for i in 0..(a.length - 1)
-              result |= a[i] ^ b[i]
-            end
-            result == 0
-          else
-            false
-          end
-        end
+    private
+      # constant-time comparison algorithm to prevent timing attacks
+      def secure_compare(a, b)
+        return false unless a.bytesize == b.bytesize
+
+        l = a.unpack "C#{a.bytesize}"
+
+        res = 0
+        b.each_byte { |byte| res |= byte ^ l.shift }
+        res == 0
       end
 
       def generate_digest(data)
         require 'openssl' unless defined?(OpenSSL)
-        OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new(@digest), @secret, data)
+        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.const_get(@digest).new, @secret, data)
       end
   end
 end

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'securerandom'
 
 begin
   require 'openssl'
@@ -7,49 +8,78 @@ rescue LoadError, NameError
   $stderr.puts "Skipping MessageEncryptor test: broken OpenSSL install"
 else
 
-class MessageEncryptorTest < Test::Unit::TestCase
+require 'active_support/json'
+
+class MessageEncryptorTest < ActiveSupport::TestCase
+  class JSONSerializer
+    def dump(value)
+      ActiveSupport::JSON.encode(value)
+    end
+
+    def load(value)
+      ActiveSupport::JSON.decode(value)
+    end
+  end
+
   def setup
-    @encryptor = ActiveSupport::MessageEncryptor.new(ActiveSupport::SecureRandom.hex(64))
-    @data = {:some=>"data", :now=>Time.now}
+    @secret    = SecureRandom.hex(64)
+    @verifier  = ActiveSupport::MessageVerifier.new(@secret, :serializer => ActiveSupport::MessageEncryptor::NullSerializer)
+    @encryptor = ActiveSupport::MessageEncryptor.new(@secret)
+    @data = { :some => "data", :now => Time.local(2010) }
   end
-  
-  def test_simple_round_tripping
-    message = @encryptor.encrypt(@data)
-    assert_equal @data, @encryptor.decrypt(message)
-  end
-  
+
   def test_encrypting_twice_yields_differing_cipher_text
-    first_messqage = @encryptor.encrypt(@data)
-    second_message = @encryptor.encrypt(@data)
-    assert_not_equal first_messqage, second_message
+    first_message = @encryptor.encrypt_and_sign(@data).split("--").first
+    second_message = @encryptor.encrypt_and_sign(@data).split("--").first
+    assert_not_equal first_message, second_message
   end
-  
-  def test_messing_with_either_value_causes_failure
-    text, iv = @encryptor.encrypt(@data).split("--")
+
+  def test_messing_with_either_encrypted_values_causes_failure
+    text, iv = @verifier.verify(@encryptor.encrypt_and_sign(@data)).split("--")
     assert_not_decrypted([iv, text] * "--")
     assert_not_decrypted([text, munge(iv)] * "--")
     assert_not_decrypted([munge(text), iv] * "--")
     assert_not_decrypted([munge(text), munge(iv)] * "--")
   end
-  
+
+  def test_messing_with_verified_values_causes_failures
+    text, iv = @encryptor.encrypt_and_sign(@data).split("--")
+    assert_not_verified([iv, text] * "--")
+    assert_not_verified([text, munge(iv)] * "--")
+    assert_not_verified([munge(text), iv] * "--")
+    assert_not_verified([munge(text), munge(iv)] * "--")
+  end
+
   def test_signed_round_tripping
     message = @encryptor.encrypt_and_sign(@data)
     assert_equal @data, @encryptor.decrypt_and_verify(message)
   end
-  
-  
+
+  def test_alternative_serialization_method
+    encryptor = ActiveSupport::MessageEncryptor.new(SecureRandom.hex(64), SecureRandom.hex(64), :serializer => JSONSerializer.new)
+    message = encryptor.encrypt_and_sign({ :foo => 123, 'bar' => Time.utc(2010) })
+    assert_equal encryptor.decrypt_and_verify(message), { "foo" => 123, "bar" => "2010/01/01 00:00:00 +0000" }
+  end
+
   private
-    def assert_not_decrypted(value)
-      assert_raise(ActiveSupport::MessageEncryptor::InvalidMessage) do
-        @encryptor.decrypt(value)
-      end
+
+  def assert_not_decrypted(value)
+    assert_raise(ActiveSupport::MessageEncryptor::InvalidMessage) do
+      @encryptor.decrypt_and_verify(@verifier.generate(value))
     end
-    
-    def munge(base64_string)
-      bits = ActiveSupport::Base64.decode64(base64_string)
-      bits.reverse!
-      ActiveSupport::Base64.encode64s(bits)
+  end
+
+  def assert_not_verified(value)
+    assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
+      @encryptor.decrypt_and_verify(value)
     end
+  end
+
+  def munge(base64_string)
+    bits = ::Base64.decode64(base64_string)
+    bits.reverse!
+    ::Base64.strict_encode64(bits)
+  end
 end
 
 end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -1,16 +1,36 @@
 require 'abstract_unit'
 
-class MessageVerifierTest < Test::Unit::TestCase
+begin
+  require 'openssl'
+  OpenSSL::Digest::SHA1
+rescue LoadError, NameError
+  $stderr.puts "Skipping MessageVerifier test: broken OpenSSL install"
+else
+
+require 'active_support/json'
+
+class MessageVerifierTest < ActiveSupport::TestCase
+
+  class JSONSerializer
+    def dump(value)
+      ActiveSupport::JSON.encode(value)
+    end
+
+    def load(value)
+      ActiveSupport::JSON.decode(value)
+    end
+  end
+
   def setup
     @verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!")
-    @data = {:some=>"data", :now=>Time.now}
+    @data = { :some => "data", :now => Time.local(2010) }
   end
-  
+
   def test_simple_round_tripping
     message = @verifier.generate(@data)
     assert_equal @data, @verifier.verify(message)
   end
-  
+
   def test_missing_signature_raises
     assert_not_verified(nil)
     assert_not_verified("")
@@ -22,10 +42,37 @@ class MessageVerifierTest < Test::Unit::TestCase
     assert_not_verified("#{data}--#{hash.reverse}")
     assert_not_verified("purejunk")
   end
-  
+
+  def test_alternative_serialization_method
+    prev = ActiveSupport.use_standard_json_time_format
+    ActiveSupport.use_standard_json_time_format = true
+    verifier = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!", :serializer => JSONSerializer.new)
+    message = verifier.generate({ :foo => 123, 'bar' => Time.utc(2010) })
+    exp = { "foo" => 123, "bar" => "2010-01-01T00:00:00Z" }
+    assert_equal exp, verifier.verify(message)
+  ensure
+    ActiveSupport.use_standard_json_time_format = prev
+  end
+
+  def test_raise_error_when_argument_class_is_not_loaded
+    # To generate the valid message below:
+    #
+    #   AutoloadClass = Struct.new(:foo)
+    #   valid_message = @verifier.generate(foo: AutoloadClass.new('foo'))
+    #
+    valid_message = "BAh7BjoIZm9vbzonTWVzc2FnZVZlcmlmaWVyVGVzdDo6QXV0b2xvYWRDbGFzcwY6CUBmb29JIghmb28GOgZFVA==--f3ef39a5241c365083770566dc7a9eb5d6ace914"
+    exception = assert_raise(ArgumentError, NameError) do
+      @verifier.verify(valid_message)
+    end
+    assert_includes ["uninitialized constant MessageVerifierTest::AutoloadClass",
+                    "undefined class/module MessageVerifierTest::AutoloadClass"], exception.message
+  end
+
   def assert_not_verified(message)
     assert_raise(ActiveSupport::MessageVerifier::InvalidSignature) do
       @verifier.verify(message)
     end
   end
+end
+
 end


### PR DESCRIPTION
This backports the versions of these classes from upstream rails at 051d289030a6cb86590cd1b619eae1879b48458a

The most notable differences are the ability to use non-Marshal serializers and also specify a signature key which is distinct from the encryption key. Otherwise these are backwards compatible with their Rails 2.x counterparts. The implementation is also, in general, less wonky (see the old constant time comparison code vs the new code)

Using a non-Marshal serializer (e.g. the provided NullSerializer, or JSONSerializer) will make interop with non-Rails things easier.
