### PR TITLE
Bring back config.action_view.cache_template_loading

### DIFF
--- a/actionpack/lib/action_view/base.rb
+++ b/actionpack/lib/action_view/base.rb
@@ -186,6 +186,14 @@ module ActionView #:nodoc:
     class << self
       delegate :erb_trim_mode=, :to => 'ActionView::Template::Handlers::ERB'
       delegate :logger, :to => 'ActionController::Base', :allow_nil => true
+
+      def cache_template_loading
+        ActionView::Resolver.caching?
+      end
+
+      def cache_template_loading=(value)
+        ActionView::Resolver.caching = value
+      end
     end
 
     attr_accessor :base_path, :assigns, :template_extension, :lookup_context

--- a/actionpack/lib/action_view/railtie.rb
+++ b/actionpack/lib/action_view/railtie.rb
@@ -35,5 +35,13 @@ module ActionView
         end
       end
     end
+
+    initializer "action_view.caching" do |app|
+      ActiveSupport.on_load(:action_view) do
+        if app.config.action_view.cache_template_loading.nil?
+          ActionView::Resolver.caching = app.config.cache_classes
+        end
+      end
+    end
   end
 end

--- a/actionpack/lib/action_view/template/resolver.rb
+++ b/actionpack/lib/action_view/template/resolver.rb
@@ -5,6 +5,13 @@ require "action_view/template"
 module ActionView
   # = Action View Resolver
   class Resolver
+    cattr_accessor :caching
+    self.caching = true
+
+    class << self
+      alias :caching? :caching
+    end
+
     def initialize
       @cached = Hash.new { |h1,k1| h1[k1] =
         Hash.new { |h2,k2| h2[k2] = Hash.new { |h3, k3| h3[k3] = {} } } }
@@ -23,9 +30,7 @@ module ActionView
 
   private
 
-    def caching?
-      @caching ||= !defined?(Rails.application) || Rails.application.config.cache_classes
-    end
+    delegate :caching?, :to => "self.class"
 
     # This is what child classes implement. No defaults are needed
     # because Resolver guarantees that the arguments are present and

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -358,5 +358,43 @@ module ApplicationTests
       get "/"
       assert_equal 'true', last_response.body
     end
+
+    test "config.action_view.cache_template_loading with cache_classes default" do
+      add_to_config "config.cache_classes = true"
+      require "#{app_path}/config/environment"
+      require 'action_view/base'
+
+      assert ActionView::Resolver.caching?
+    end
+
+    test "config.action_view.cache_template_loading without cache_classes default" do
+      add_to_config "config.cache_classes = false"
+      require "#{app_path}/config/environment"
+      require 'action_view/base'
+
+      assert !ActionView::Resolver.caching?
+    end
+
+    test "config.action_view.cache_template_loading = false" do
+      add_to_config <<-RUBY
+        config.cache_classes = true
+        config.action_view.cache_template_loading = false
+      RUBY
+      require "#{app_path}/config/environment"
+      require 'action_view/base'
+
+      assert !ActionView::Resolver.caching?
+    end
+
+    test "config.action_view.cache_template_loading = true" do
+      add_to_config <<-RUBY
+        config.cache_classes = false
+        config.action_view.cache_template_loading = true
+      RUBY
+      require "#{app_path}/config/environment"
+      require 'action_view/base'
+
+      assert ActionView::Resolver.caching?
+    end
   end
 end


### PR DESCRIPTION
It was missing from `3.0` and was restored back in `3.1`: https://rails.lighthouseapp.com/projects/8994/tickets/5847-rails-301-configaction_viewcache_template_loading-is-missing

We're using it in our environments files.

/cc @tamird @JackDanger
