### PR TITLE
Fix validates_length_of

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -16,6 +16,10 @@ module ActiveModel
           options[:maximum] -= 1 if range.exclude_end?
         end
 
+        if options[:allow_blank] == false && options[:minimum].nil? && options[:is].nil?
+          options[:minimum] = 1
+        end
+
         super(options.reverse_merge(:tokenizer => DEFAULT_TOKENIZER))
       end
 
@@ -37,14 +41,14 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         value = options[:tokenizer].call(value) if value.kind_of?(String)
+        value_length = value.respond_to?(:length) ? value.length : value.to_s.length
 
         CHECKS.each do |key, validity_check|
           next unless check_value = options[key]
 
-          value ||= [] if key == :maximum
-
-          value_length = value.respond_to?(:length) ? value.length : value.to_s.length
-          next if value_length.send(validity_check, check_value)
+          if !value.nil? || skip_nil_check?(key)
+            next if value_length.send(validity_check, check_value)
+          end
 
           errors_options = options.except(*RESERVED_OPTIONS)
           errors_options[:count] = check_value
@@ -54,6 +58,18 @@ module ActiveModel
 
           record.errors.add(attribute, MESSAGES[key], errors_options)
         end
+      end
+
+      private
+
+      def tokenize(value)
+        if options[:tokenizer] && value.kind_of?(String)
+          options[:tokenizer].call(value)
+        end || value
+      end
+
+      def skip_nil_check?(key)
+        key == :maximum && options[:allow_nil].nil? && options[:allow_blank].nil?
       end
     end
 
@@ -74,7 +90,8 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:minimum</tt> - The minimum size of the attribute.
-      # * <tt>:maximum</tt> - The maximum size of the attribute.
+      # * <tt>:maximum</tt> - The maximum size of the attribute. Allows +nil+ by
+      #   default if not used with :minimum.
       # * <tt>:is</tt> - The exact size of the attribute.
       # * <tt>:within</tt> - A range specifying the minimum and maximum size of the attribute.
       # * <tt>:in</tt> - A synonym(or alias) for <tt>:within</tt>.

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -367,4 +367,43 @@ class LengthValidationTest < ActiveModel::TestCase
   ensure
     Person.reset_callbacks(:validate)
   end
+
+  def test_validates_length_of_using_maximum_should_not_allow_nil_when_nil_not_allowed
+    Topic.validates_length_of :title, :maximum => 10, :allow_nil => false
+    t = Topic.new
+    assert t.invalid?
+  end
+
+  def test_validates_length_of_using_maximum_should_not_allow_nil_and_empty_string_when_blank_not_allowed
+    Topic.validates_length_of :title, :maximum => 10, :allow_blank => false
+    t = Topic.new
+    assert t.invalid?
+
+    t.title = ""
+    assert t.invalid?
+  end
+
+  def test_validates_length_of_using_both_minimum_and_maximum_should_not_allow_nil
+    Topic.validates_length_of :title, :minimum => 5, :maximum => 10
+    t = Topic.new
+    assert t.invalid?
+  end
+
+  def test_validates_length_of_using_minimum_0_should_not_allow_nil
+    Topic.validates_length_of :title, :minimum => 0
+    t = Topic.new
+    assert t.invalid?
+
+    t.title = ""
+    assert t.valid?
+  end
+
+  def test_validates_length_of_using_is_0_should_not_allow_nil
+    Topic.validates_length_of :title, :is => 0
+    t = Topic.new
+    assert t.invalid?
+
+    t.title = ""
+    assert t.valid?
+  end
 end


### PR DESCRIPTION
When you declare `validates_length_of` without `: minimum` and with `:allow_nil => false` it will return `true` on `nil` values. This bug wasn't fixed up until [4.0 release](https://github.com/rails/rails/commit/ea76e9a3126998578d683783483aa695cb6b657e)

We're using such combination in one place. While it can be fixed just by adding `:minimum => 1` to validator it will be very hard for debug. What's even worst, when model's validations aren't tested thoroughly with assumption that they just work as supposed it will be hidden bug.

I've back ported the fix.

/cc @JackDanger @tamird @robolson 
