### PR TITLE
add `#respond_to_missing?` to `ActionController::TestUploadedFile`

### DIFF
--- a/actionpack/lib/action_controller/test_process.rb
+++ b/actionpack/lib/action_controller/test_process.rb
@@ -389,6 +389,10 @@ module ActionController #:nodoc:
     def method_missing(method_name, *args, &block) #:nodoc:
       @tempfile.__send__(method_name, *args, &block)
     end
+
+    def respond_to_missing?(*args)
+      @tempfile.respond_to?(*args)
+    end
   end
 
   module TestProcess


### PR DESCRIPTION
@rudle @strzalek this helps us with `aws-sdk` compatibility in tests
