### PR TITLE
Allow to set headers on request object in #recognize_path

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -500,11 +500,11 @@ module ActionDispatch
       end
 
       def recognize_path(path, environment = {})
-        method = (environment[:method] || "GET").to_s.upcase
+        environment[:method] = (environment[:method] || "GET").to_s.upcase
         path = Rack::Mount::Utils.normalize_path(path) unless path =~ %r{://}
 
         begin
-          env = Rack::MockRequest.env_for(path, {:method => method})
+          env = Rack::MockRequest.env_for(path, environment)
         rescue URI::InvalidURIError => e
           raise ActionController::RoutingError, e.message
         end


### PR DESCRIPTION
Helpful when testing routes with host/protocol constraint:

``` ruby
Rails.application.routes.recognize_path('/foo/bar', :method => 'get', 'HTTPS' => 'on', HTTP_HOST => example.com)
```

/cc @tamird  
