### PR TITLE
Reverse include_password defaults for dbconsole

### DIFF
--- a/railties/lib/rails/commands/dbconsole.rb
+++ b/railties/lib/rails/commands/dbconsole.rb
@@ -20,12 +20,12 @@ module Rails
     end
 
     def start
-      include_password = false
+      include_password = true
       options = {}
       OptionParser.new do |opt|
         opt.banner = "Usage: dbconsole [options] [environment]"
-        opt.on("-p", "--include-password", "Automatically provide the password from database.yml") do |v|
-          include_password = true
+        opt.on("-p", "--include-password", "Ask for password") do |v|
+          include_password = false
         end
 
         opt.on("--mode [MODE]", ['html', 'list', 'line', 'column'],


### PR DESCRIPTION
Unfortunately there's no way to configure it. I'll think about some nice way to introduce it (maybe something like `config.console.dbconsole.include_password =` in application.rb?) and send PR for upstream rails. 

Meanwhile if we want to have `-p` by default, we need to use this hack :see_no_evil: 

@square/railsfork-contributors 
