### PR TITLE
Use HashWithIndifferentAccess for reflections

### DIFF
--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -242,7 +242,8 @@ class ReflectionTest < ActiveRecord::TestCase
 
   private
     def assert_reflection(klass, association, options)
-      assert reflection = klass.reflect_on_association(association)
+      assert reflection = klass.reflect_on_association(association.to_s)
+      assert reflection == klass.reflect_on_association(association.to_sym)
       options.each do |method, value|
         assert_equal(value, reflection.send(method))
       end

--- a/activesupport/lib/active_support/core_ext/class/inheritable_attributes.rb
+++ b/activesupport/lib/active_support/core_ext/class/inheritable_attributes.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext/object/duplicable'
 require 'active_support/core_ext/array/extract_options'
+require 'active_support/core_ext/hash/indifferent_access'
 
 # Retained for backward compatibility.  Methods are now included in Class.
 module ClassInheritableAttributes # :nodoc:
@@ -136,7 +137,7 @@ class Class # :nodoc:
   end
 
   def write_inheritable_hash(key, hash)
-    write_inheritable_attribute(key, {}) if read_inheritable_attribute(key).nil?
+    write_inheritable_attribute(key, {}.with_indifferent_access) if read_inheritable_attribute(key).nil?
     write_inheritable_attribute(key, read_inheritable_attribute(key).merge(hash))
   end
 

--- a/activesupport/test/core_ext/class/class_inheritable_attributes_test.rb
+++ b/activesupport/test/core_ext/class/class_inheritable_attributes_test.rb
@@ -1,5 +1,6 @@
 require 'abstract_unit'
 require 'active_support/core_ext/class/inheritable_attributes'
+require 'active_support/core_ext/hash/slice'
 
 class ClassInheritableAttributesTest < Test::Unit::TestCase
   def setup
@@ -138,12 +139,12 @@ class ClassInheritableAttributesTest < Test::Unit::TestCase
     assert_nil @klass.new.a
 
     @klass.a = { :a => 'a' }
-    assert_equal({ :a => 'a' }, @klass.a)
-    assert_equal({ :a => 'a' }, @klass.new.a)
+    assert_equal('a', @klass.a[:a])
+    assert_equal('a', @klass.new.a[:a])
 
     @klass.new.a = { :b => 'b' }
-    assert_equal({ :a => 'a', :b => 'b' }, @klass.a)
-    assert_equal({ :a => 'a', :b => 'b' }, @klass.new.a)
+    assert_equal(['a', 'b'], @klass.a.slice(:a, :b).values)
+    assert_equal(['a', 'b'], @klass.new.a.slice(:a, :b).values)
   end
 
   def test_inheritance


### PR DESCRIPTION
This prevents a bug where we try to access reflections with string
keys rather than symbols.
