### PR TITLE
Backport mime-type parsing fixes

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -80,6 +80,10 @@ module Mime
     end
 
     class << self
+
+      TRAILING_STAR_REGEXP = /(text|application)\/\*/
+      PARAMETER_SEPARATOR_REGEXP = /;\s*\w+="?\w+"?/
+
       def lookup(string)
         LOOKUP[string]
       end
@@ -105,15 +109,29 @@ module Mime
 
       def parse(accept_header)
         if accept_header !~ /,/
-          [Mime::Type.lookup(accept_header)]
+          accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
+          if accept_header =~ TRAILING_STAR_REGEXP
+            parse_data_with_trailing_star($1)
+          else
+            [Mime::Type.lookup(accept_header)]
+          end
         else
           # keep track of creation order to keep the subsequent sort stable
-          list = []
-          accept_header.split(/,/).each_with_index do |header, index|
-            params, q = header.split(/;\s*q=/)
-            if params
+          list, index = [], 0
+          accept_header.split(/,/).each do |header|
+            params, q = header.split(PARAMETER_SEPARATOR_REGEXP)
+            if params.present?
               params.strip!
-              list << AcceptItem.new(index, params, q) unless params.empty?
+
+              if params =~ TRAILING_STAR_REGEXP
+                parse_data_with_trailing_star($1).each do |m|
+                  list << AcceptItem.new(index, m.to_s, q)
+                  index += 1
+                end
+              else
+                list << AcceptItem.new(index, params, q)
+                index += 1
+              end
             end
           end
           list.sort!
@@ -159,6 +177,30 @@ module Mime
           list.map! { |i| Mime::Type.lookup(i.name) }.uniq!
           list
         end
+      end
+
+      # input: 'text'
+      # returned value:  [Mime::JSON, Mime::XML, Mime::ICS, Mime::HTML, Mime::CSS, Mime::CSV, Mime::JS, Mime::YAML, Mime::TEXT]
+      #
+      # input: 'application'
+      # returned value: [Mime::HTML, Mime::JS, Mime::XML, Mime::YAML, Mime::ATOM, Mime::JSON, Mime::RSS, Mime::URL_ENCODED_FORM]
+      def parse_data_with_trailing_star(input)
+        Mime::SET.select { |m| m =~ input }
+      end
+
+      # This method is opposite of register method.
+      #
+      # Usage:
+      #
+      # Mime::Type.unregister(:mobile)
+      def unregister(symbol)
+        symbol = symbol.to_s.upcase
+        mime = Mime.const_get(symbol)
+        Mime.instance_eval { remove_const(symbol) }
+
+        SET.delete_if { |v| v.eql?(mime) }
+        LOOKUP.delete_if { |k,v| v.eql?(mime) }
+        EXTENSION_LOOKUP.delete_if { |k,v| v.eql?(mime) }
       end
     end
 

--- a/actionpack/test/controller/mime_responds_test.rb
+++ b/actionpack/test/controller/mime_responds_test.rb
@@ -89,8 +89,6 @@ class RespondToController < ActionController::Base
     end
   end
 
-  Mime::Type.register("text/x-mobile", :mobile)
-
   def custom_constant_handling
     respond_to do |type|
       type.html   { render :text => "HTML"   }
@@ -125,8 +123,6 @@ class RespondToController < ActionController::Base
       type.js
     end
   end
-
-  Mime::Type.register_alias("text/html", :iphone)
 
   def iphone_with_html_response_type
     request.format = :iphone if request.env["HTTP_ACCEPT"] == "text/iphone"
@@ -166,10 +162,14 @@ class RespondToControllerTest < ActionController::TestCase
   def setup
     super
     @request.host = "www.example.com"
+    Mime::Type.register_alias("text/html", :iphone)
+    Mime::Type.register("text/x-mobile", :mobile)
   end
 
   def teardown
     super
+    Mime::Type.unregister(:iphone)
+    Mime::Type.unregister(:mobile)
   end
 
   def test_html
@@ -971,7 +971,13 @@ class MimeControllerLayoutsTest < ActionController::TestCase
   def setup
     super
     @request.host = "www.example.com"
-  end
+    Mime::Type.register_alias("text/html", :iphone)
+   end
+
+   def teardown
+     super
+     Mime::Type.unregister(:iphone)
+   end
 
   def test_missing_layout_renders_properly
     get :index

--- a/actionpack/test/dispatch/mime_type_test.rb
+++ b/actionpack/test/dispatch/mime_type_test.rb
@@ -10,6 +10,34 @@ class MimeTypeTest < ActiveSupport::TestCase
     end
   end
 
+  test "parse text with trailing star at the beginning" do
+    accept = "text/*, text/html, application/json, multipart/form-data"
+    expect = [Mime::HTML, Mime::TEXT, Mime::JS, Mime::CSS, Mime::ICS, Mime::CSV, Mime::XML, Mime::YAML, Mime::JSON, Mime::MULTIPART_FORM]
+    parsed = Mime::Type.parse(accept)
+    assert_equal expect, parsed
+  end
+
+  test "parse text with trailing star in the end" do
+    accept = "text/html, application/json, multipart/form-data, text/*"
+    expect = [Mime::HTML, Mime::JSON, Mime::MULTIPART_FORM, Mime::TEXT, Mime::JS, Mime::CSS, Mime::ICS, Mime::CSV, Mime::XML, Mime::YAML]
+    parsed = Mime::Type.parse(accept)
+    assert_equal expect, parsed
+  end
+
+  test "parse text with trailing star" do
+    accept = "text/*"
+    expect = [Mime::HTML, Mime::TEXT, Mime::JS, Mime::CSS, Mime::ICS, Mime::CSV, Mime::XML, Mime::YAML, Mime::JSON]
+    parsed = Mime::Type.parse(accept)
+    assert_equal expect, parsed
+  end
+
+  test "parse application with trailing star" do
+    accept = "application/*"
+    expect = [Mime::HTML, Mime::JS, Mime::XML, Mime::RSS, Mime::ATOM, Mime::YAML, Mime::URL_ENCODED_FORM, Mime::JSON, Mime::PDF]
+    parsed = Mime::Type.parse(accept)
+    assert_equal expect, parsed
+  end
+
   test "parse without q" do
     accept = "text/xml,application/xhtml+xml,text/yaml,application/xml,text/html,image/png,text/plain,application/pdf,*/*"
     expect = [Mime::HTML, Mime::XML, Mime::YAML, Mime::PNG, Mime::TEXT, Mime::PDF, Mime::ALL]
@@ -19,6 +47,24 @@ class MimeTypeTest < ActiveSupport::TestCase
   test "parse with q" do
     accept = "text/xml,application/xhtml+xml,text/yaml; q=0.3,application/xml,text/html; q=0.8,image/png,text/plain; q=0.5,application/pdf,*/*; q=0.2"
     expect = [Mime::HTML, Mime::XML, Mime::PNG, Mime::PDF, Mime::TEXT, Mime::YAML, Mime::ALL]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
+  test "parse single media range with q" do
+    accept = "text/html;q=0.9"
+    expect = [Mime::HTML]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
+  test "parse any media range with q" do
+    accept = "*/*;q=0.9"
+    expect = [Mime::ALL]
+    assert_equal expect, Mime::Type.parse(accept)
+  end
+
+  test "parse arbitrary media type parameters" do
+    accept = 'multipart/form-data; boundary="simple boundary"'
+    expect = [Mime::MULTIPART_FORM]
     assert_equal expect, Mime::Type.parse(accept)
   end
 


### PR DESCRIPTION
Backport fixes to mime type parsing which are causing `ActiveRecord::MissingTemplate` exceptions when we're being crawled by googlebot and others.

@tamird @JackDanger @ecin
