### PR TITLE
if format is unknown NullMimeTypeObject is returned

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -86,6 +86,8 @@ module AbstractController
     def render(*args, &block)
       options = _normalize_render(*args, &block)
       self.response_body = render_to_body(options)
+      _process_format(rendered_format) if rendered_format
+      self.response_body
     end
 
     # Raw rendering of a template to a string. Just convert the results of

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -6,7 +6,7 @@ module ActionController
 
     # Before processing, set the request formats in current controller formats.
     def process_action(*) #:nodoc:
-      self.formats = request.formats.select { |x| !x.nil? }.map(&:ref)
+      self.formats = request.formats.map(&:ref).compact
       super
     end
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -6,7 +6,7 @@ module ActionController
 
     # Before processing, set the request formats in current controller formats.
     def process_action(*) #:nodoc:
-      self.formats = request.formats.map { |x| x.ref }
+      self.formats = request.formats.select { |x| !x.nil? }.map(&:ref)
       super
     end
 

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -31,6 +31,11 @@ module ActionController
 
     private
 
+    def _process_format(format)
+      super
+      self.content_type ||= format.to_s
+    end
+
     # Normalize arguments by catching blocks and setting them on :update.
     def _normalize_args(action=nil, options={}, &blk) #:nodoc:
       options = super

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -46,7 +46,7 @@ module ActionDispatch
       #   GET /posts/5       | request.format => Mime::HTML or MIME::JS, or request.accepts.first
       #
       def format(view_path = [])
-        formats.first
+        formats.first || Mime::NullType.instance
       end
 
       def formats

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -28,7 +28,7 @@ module Mime
   class << self
     def [](type)
       return type if type.is_a?(Type)
-      Type.lookup_by_extension(type) || NullType.instance
+      Type.lookup_by_extension(type)
     end
 
     def fetch(type)

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -283,9 +283,7 @@ module Mime
       true
     end
 
-    def ref
-      nil
-    end
+    def ref; end
 
     def respond_to_missing?(method, include_private = false)
       method.to_s.ends_with? '?'

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -1,6 +1,7 @@
 require 'set'
-require 'active_support/core_ext/class/attribute_accessors'
-require 'active_support/core_ext/object/blank'
+require 'singleton'
+require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/core_ext/string/starts_ends_with'
 
 module Mime
   class Mimes < Array
@@ -27,7 +28,7 @@ module Mime
   class << self
     def [](type)
       return type if type.is_a?(Type)
-      Type.lookup_by_extension(type)
+      Type.lookup_by_extension(type) || NullType.instance
     end
 
     def fetch(type)
@@ -276,6 +277,8 @@ module Mime
   end
 
   class NullType
+    include Singleton
+
     def nil?
       true
     end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -117,11 +117,7 @@ module Mime
       def parse(accept_header)
         if accept_header !~ /,/
           accept_header = accept_header.split(PARAMETER_SEPARATOR_REGEXP).first
-          if accept_header =~ TRAILING_STAR_REGEXP
-            parse_data_with_trailing_star($1)
-          else
-            [Mime::Type.lookup(accept_header)]
-          end
+          parse_trailing_star(accept_header) || [Mime::Type.lookup(accept_header)]
         else
           # keep track of creation order to keep the subsequent sort stable
           list, index = [], 0

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -278,10 +278,14 @@ module Mime
         end
       end
   end
-  
+
   class NullType
     def nil?
       true
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      method.to_s.ends_with? '?'
     end
 
     private

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -284,6 +284,10 @@ module Mime
       true
     end
 
+    def ref
+      nil
+    end
+
     def respond_to_missing?(method, include_private = false)
       method.to_s.ends_with? '?'
     end

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -24,9 +24,16 @@ module Mime
   EXTENSION_LOOKUP = {}
   LOOKUP           = Hash.new { |h, k| h[k] = Type.new(k) unless k.blank? }
 
-  def self.[](type)
-    return type if type.is_a?(Type)
-    Type.lookup_by_extension(type.to_s)
+  class << self
+    def [](type)
+      return type if type.is_a?(Type)
+      Type.lookup_by_extension(type)
+    end
+
+    def fetch(type)
+      return type if type.is_a?(Type)
+      EXTENSION_LOOKUP.fetch(type.to_s) { |k| yield k }
+    end
   end
 
   # Encapsulates the notion of a mime type. Can be used at render time, for example, with:
@@ -270,6 +277,17 @@ module Mime
           super
         end
       end
+  end
+  
+  class NullType
+    def nil?
+      true
+    end
+
+    private
+    def method_missing(method, *args)
+      false if method.to_s.ends_with? '?'
+    end
   end
 end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -1056,6 +1056,12 @@ class RenderTest < ActionController::TestCase
     assert_equal '<test>passed formatted html erb</test>', @response.body
   end
 
+  def test_should_render_formatted_html_erb_template_with_bad_accepts_header
+    @request.env["HTTP_ACCEPT"] = "; a=dsf"
+    get :formatted_xml_erb
+    assert_equal '<test>passed formatted html erb</test>', @response.body
+  end
+
   def test_should_render_formatted_html_erb_template_with_faulty_accepts_header
     @request.accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, appliction/x-shockwave-flash, */*"
     get :formatted_xml_erb

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -148,7 +148,7 @@ class SendFileTest < ActionController::TestCase
     }
 
     @controller.headers = {}
-    assert !@controller.send(:send_file_headers!, options)
+    assert_raise(ArgumentError) { @controller.send(:send_file_headers!, options) }
   end
 
   def test_send_file_headers_guess_type_from_extension

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -148,7 +148,7 @@ class SendFileTest < ActionController::TestCase
     }
 
     @controller.headers = {}
-    assert_raise(ArgumentError){ @controller.send(:send_file_headers!, options) }
+    assert !@controller.send(:send_file_headers!, options)
   end
 
   def test_send_file_headers_guess_type_from_extension

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -501,9 +501,18 @@ class RequestTest < ActiveSupport::TestCase
 
     request = stub_request
     request.expects(:parameters).at_least_once.returns({ :format => :unknown })
-    assert request.formats.empty?
+    assert_instance_of Mime::NullType, request.format
   end
 
+  test "format is not nil with unknown format" do
+    request = stub_request
+    request.expects(:parameters).at_least_once.returns({ format: :hello })
+    assert_equal request.format.nil?, true
+    assert_equal request.format.html?, false
+    assert_equal request.format.xml?, false
+    assert_equal request.format.json?, false
+  end
+  
   test "formats with xhr request" do
     request = stub_request 'HTTP_X_REQUESTED_WITH' => "XMLHttpRequest"
     request.expects(:parameters).at_least_once.returns({})


### PR DESCRIPTION
Backporting this commit so that request.format is never nil
