### PR TITLE
Mysql bool fix

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -200,6 +200,12 @@ module ActiveRecord
         true
       end
 
+      def type_cast(value, column)
+        return super unless value == true || value == false
+
+        value ? 1 : 0
+      end
+
       # MySQL 4 technically support transaction isolation, but it is affected by a bug
       # where the transaction level gets persisted for the whole session:
       #

--- a/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb
@@ -160,12 +160,6 @@ module ActiveRecord
 
       # QUOTING ==================================================
 
-      def type_cast(value, column)
-        return super unless value == true || value == false
-
-        value ? 1 : 0
-      end
-
       def quote_string(string) #:nodoc:
         @connection.quote(string)
       end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -1,0 +1,91 @@
+require "cases/helper"
+
+class Mysql2BooleanTest < ActiveRecord::TestCase
+  self.use_transactional_fixtures = false
+
+  class BooleanType < ActiveRecord::Base
+    self.table_name = "mysql_booleans"
+  end
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table("mysql_booleans") do |t|
+      t.boolean "archived"
+      t.string "published", limit: 1
+    end
+    BooleanType.reset_column_information
+
+    @emulate_booleans = ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans
+  end
+
+  teardown do
+    emulate_booleans @emulate_booleans
+    @connection.drop_table "mysql_booleans"
+  end
+
+  test "column type with emulated booleans" do
+    emulate_booleans true
+
+    assert_equal :boolean, boolean_column.type
+    assert_equal :string, string_column.type
+  end
+
+  test "column type without emulated booleans" do
+    emulate_booleans false
+
+    assert_equal :integer, boolean_column.type
+    assert_equal :string, string_column.type
+  end
+
+  test "test type casting with emulated booleans" do
+    emulate_booleans true
+
+    boolean = BooleanType.create!(archived: true, published: true)
+    attributes = boolean.reload.attributes_before_type_cast
+
+    assert_equal 1, attributes["archived"]
+    assert_equal "1", attributes["published"]
+
+    assert_equal "t", @connection.type_cast(true, boolean_column)
+    assert_equal "t", @connection.type_cast(true, string_column)
+  end
+
+  test "test type casting without emulated booleans" do
+    emulate_booleans false
+
+    boolean = BooleanType.create!(archived: true, published: true)
+    attributes = boolean.reload.attributes_before_type_cast
+
+    assert_equal 1, attributes["archived"]
+    assert_equal "1", attributes["published"]
+
+    assert_equal 1, @connection.type_cast(true, boolean_column)
+    assert_equal "t", @connection.type_cast(true, string_column)
+  end
+
+  test "with booleans stored as 1 and 0" do
+    @connection.execute "INSERT INTO mysql_booleans(archived, published) VALUES(1, '1')"
+    boolean = BooleanType.first
+    assert_equal true, boolean.archived
+    assert_equal "1", boolean.published
+  end
+
+  test "with booleans stored as t" do
+    @connection.execute "INSERT INTO mysql_booleans(published) VALUES('t')"
+    boolean = BooleanType.first
+    assert_equal "t", boolean.published
+  end
+
+  def boolean_column
+    BooleanType.columns.find { |c| c.name == 'archived' }
+  end
+
+  def string_column
+    BooleanType.columns.find { |c| c.name == 'published' }
+  end
+
+  def emulate_booleans(value)
+    ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans = value
+    BooleanType.reset_column_information
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/boolean_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/boolean_test.rb
@@ -46,8 +46,8 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
     assert_equal 1, attributes["archived"]
     assert_equal "1", attributes["published"]
 
-    assert_equal "t", @connection.type_cast(true, boolean_column)
-    assert_equal "t", @connection.type_cast(true, string_column)
+    assert_equal 1, @connection.type_cast(true, boolean_column)
+    assert_equal 1, @connection.type_cast(true, string_column)
   end
 
   test "test type casting without emulated booleans" do
@@ -60,7 +60,7 @@ class Mysql2BooleanTest < ActiveRecord::TestCase
     assert_equal "1", attributes["published"]
 
     assert_equal 1, @connection.type_cast(true, boolean_column)
-    assert_equal "t", @connection.type_cast(true, string_column)
+    assert_equal 1, @connection.type_cast(true, string_column)
   end
 
   test "with booleans stored as 1 and 0" do


### PR DESCRIPTION
Booleans are broken in AR when using mysql2 & tinyint. This  backports [fix](https://github.com/rails/rails/pull/12425) of the [issue described here](https://github.com/rails/rails/issues/11119)

It is fixed in `4-1-stable`.

/cc @square/railsfork-contributors 
